### PR TITLE
Replace react-intersection-observer with useInView hook from Framer

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,7 +1,7 @@
 'use client'
+import { useRef } from 'react';
 import styles from './page.module.css'
-import { motion } from 'framer-motion';
-import { useInView } from 'react-intersection-observer';
+import { motion, useInView } from 'framer-motion';
 
 const phrases = [
   "It is a long established fact",
@@ -23,16 +23,13 @@ export default function Home() {
 }
 
 export function MaskText() {
+  const ref = useRef(null)
+  const inView = useInView(ref, {once: true, amount: 0.75})
 
   const animation = {
     initial: {y: "100%"},
     enter: i => ({y: "0", transition: {duration: 0.75, ease: [0.33, 1, 0.68, 1],  delay: 0.075 * i}})
   }
-
-  const { ref, inView, entry } = useInView({
-    threshold: 0.75,
-    triggerOnce: true
-  });
 
   return(
     <div ref={ref} className={styles.body}>


### PR DESCRIPTION
Hi, your guide was very helpful.

To reduce the number dependencies, I replaced `react-intersection-observer ` with `useInView` [hook from Framer](https://motion.dev/docs/react-use-in-view)
No need to merge really, wanted to use this in case someone stumbles upon this.

Thanks for creating dope sh*t :)